### PR TITLE
Pad child fake alg

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -7,6 +7,8 @@ Dependencies:
 To build from Git:
 
 % autoreconf --install
+# In Mac OS X with libraries installed via Homebrew:
+# LDFLAGS=-L/usr/local/opt/openssl/lib CPPFLAGS=-I/usr/local/opt/openssl/include ./configure --with-ldns=<path...> --with-evldns=<path...>
 % ./configure --with-ldns=<path...> --with-evldns=<path...>
 % make
 

--- a/src/glueless-child.cc
+++ b/src/glueless-child.cc
@@ -21,9 +21,6 @@
 #include "process.h"
 #include "logging.h"
 
-// Global variable
-int	n_sigs = 0;
-
 class ChildZone {
 
 	ldns_rdf				*origin;
@@ -50,7 +47,7 @@ public:
 
 public:
 	void main_callback(evldns_server_request *srq, ldns_rdf *qname, ldns_rr_type qtype);
-	void apex_callback(ldns_pkt *resp, ldns_rdf *qname, ldns_rr_type qtype, bool dnssec_ok);
+	void apex_callback(ldns_pkt *resp, ldns_rdf *qname, ldns_rr_type qtype, bool dnssec_ok, int pad_adj);
 	void sub_callback(ldns_pkt *resp, ldns_rdf *qname, ldns_rr_type qtype, bool dnssec_ok);
 };
 
@@ -106,9 +103,17 @@ void DynamicZone::main_callback(evldns_server_request *srq, ldns_rdf *qname, ldn
 	auto answer = ldns_pkt_answer(resp);
 	auto authority = ldns_pkt_authority(resp);
 	bool dnssec_ok = ldns_pkt_edns_do(req);
+	char host[NI_MAXHOST], port[NI_MAXSERV];
+	int pad_adj = 0;
 
 	if (ldns_dname_compare(qname, origin) == 0) {
-		apex_callback(resp, qname, qtype, dnssec_ok);
+    // Determine the client's address family in order to derive whether the
+		// query at the sibling was for an A or a AAAA RR and adjust the padding
+		// later on
+		if (((struct sockaddr *)&srq->addr)->sa_family == AF_INET6) {
+			pad_adj = 12;
+		}
+		apex_callback(resp, qname, qtype, dnssec_ok, pad_adj);
 	} else if (ldns_dname_is_subdomain(qname, origin)) {
 		sub_callback(resp, qname, qtype, dnssec_ok);
 	} else {
@@ -119,7 +124,45 @@ void DynamicZone::main_callback(evldns_server_request *srq, ldns_rdf *qname, ldn
 	ldns_pkt_set_nscount(resp, ldns_rr_list_rr_count(authority));
 }
 
-void DynamicZone::apex_callback(ldns_pkt *resp, ldns_rdf *qname, ldns_rr_type qtype, bool dnssec_ok)
+static ldns_rr* add_stuffing(ldns_rr *old_sig, ldns_rdf *qname, unsigned int type, unsigned int len)
+{
+	if (len > 8192) {
+		return NULL;
+	}
+
+	/* The Child response without padding already includes a response and an
+	RRSIG. In the case of a DNSKEY response with a padding bogus RRSIG in order
+	for the total size to be the same as the size of the response from the
+	sibling, the padding value needs to be reduced by 460 (0x1cc) bytes. */
+	len -= 460;
+	if (len < 0) {
+		return NULL;
+	}
+
+	uint8_t *data = (uint8_t*)malloc(len);
+	ldns_rr *new_sig = ldns_rr_clone(old_sig);
+		
+	// Adjust fields
+	// Change the algorithm to some imaginary number
+	auto rdata_alg = ldns_rr_rdf(new_sig, 1);
+	auto data_field = (uint8_t *)rdata_alg->_data;
+	data_field[0] = 42;
+	// Change the KEYID
+	auto rdata_keyid = ldns_rr_rdf(new_sig, 6);
+	data_field = (uint8_t *)rdata_keyid->_data;
+	data_field[0] = rand() % 255;
+	// Create a bunch of random data as the new signature
+	for (unsigned int i = 0; i < len; ++i) {
+		data[i] = rand() & 0xff;
+	}
+	// put the new signature in place
+	ldns_rdf *rdf = ldns_rdf_new(LDNS_RDF_TYPE_NONE, len, data);
+	ldns_rr_set_rdf(new_sig, rdf, 8);
+	
+	return new_sig;
+}
+
+void DynamicZone::apex_callback(ldns_pkt *resp, ldns_rdf *qname, ldns_rr_type qtype, bool dnssec_ok, int pad_adj)
 {
 	auto answer = ldns_pkt_answer(resp);
 	auto authority = ldns_pkt_authority(resp);
@@ -129,32 +172,22 @@ void DynamicZone::apex_callback(ldns_pkt *resp, ldns_rdf *qname, ldns_rr_type qt
 	ldns_rdf *rdata_sig;
 	ldns_rdf *rdata_keyid;
 	uint8_t *data_field;
-	
-	auto my_sigs = n_sigs;
-	
+
 	if (rrsets) {
 		LDNS_rr_list_cat_dnssec_rrs_clone(answer, rrsets->rrs);
 		if (dnssec_ok) {
-			while (my_sigs) {
-				// Create fake signatures to pad the child response
-				// 1) Clone the existing RRSIG
-				new_sig = ldns_rr_clone((rrsets->signatures)->rr);
-				// 2) get the SIG DATA
-				rdata_sig = ldns_rr_rdf(new_sig, 8);
-				data_field = (uint8_t *)rdata_sig->_data;
-				// 3) Mangle the first four bytes at random
-				data_field[0] = rand() % 25 + 65; // 65-90 = A-Z
-				data_field[1] = rand() % 25 + 65; // 65-90 = A-Z
-				data_field[2] = rand() % 25 + 65; // 65-90 = A-Z
-				data_field[3] = rand() % 25 + 65; // 65-90 = A-Z
-				// 3) Get the KEYID
-				rdata_keyid = ldns_rr_rdf(new_sig, 6);
-				data_field = (uint8_t *)rdata_keyid->_data;
-				// 4) Change the KeyID randonly
-				data_field[0] = rand() % 255;
-				// 4) Put the mangled data in place of the previous RDATA
-				ldns_dnssec_rrs_add_rr (rrsets->signatures, new_sig);
-				my_sigs--;
+			// add optional padding in the form of an arbitrary, fake, RRSIG
+			// Get the parameters from the qname
+			auto sub_label = ldns_dname_label(qname, 0);
+			
+			// Create fake signatures to pad the child response
+			unsigned int prelen, pretype, postlen, posttype;
+			auto p = (char *)ldns_rdf_data(sub_label) + 1;
+			bool dostuff = sscanf(p, "%03x-%03x-%04x-%04x-%*04x-", &prelen, &postlen, &pretype, &posttype) == 4;
+
+			if (dostuff && (prelen > 0 || postlen > 0)) {
+				new_sig = add_stuffing((rrsets->signatures)->rr, qname, LDNS_RR_TYPE_RRSIG, prelen+postlen+pad_adj);
+				ldns_dnssec_rrs_add_rr(rrsets->signatures, new_sig);
 			}
 			LDNS_rr_list_cat_dnssec_rrs_clone(answer, rrsets->signatures);
 		}
@@ -255,7 +288,6 @@ int main(int argc, char *argv[])
 			case 'k': --argc; keyfile = *++argv; break;
 			case 'l': --argc; logfile = *++argv; break;
 			case 'f': --argc; n_forks = atoi(*++argv); break;
-			case 's': --argc; n_sigs = atoi(*++argv); break;
 			default: exit(1);
 		}
 		--argc;

--- a/src/glueless-child.cc
+++ b/src/glueless-child.cc
@@ -121,9 +121,27 @@ void DynamicZone::apex_callback(ldns_pkt *resp, ldns_rdf *qname, ldns_rr_type qt
 	auto answer = ldns_pkt_answer(resp);
 	auto authority = ldns_pkt_authority(resp);
 	auto rrsets = ldns_dnssec_zone_find_rrset(zone, qname, qtype);
+	ldns_rr *new_sig;
+	ldns_rdf * rdata;
 	if (rrsets) {
 		LDNS_rr_list_cat_dnssec_rrs_clone(answer, rrsets->rrs);
 		if (dnssec_ok) {
+			while (1) {
+				# Create fake signatures to pad the child response
+				# 1) Clone an existing RRSIG
+				new_sig = ldns_rr_clone (rrsets->signatures);
+				# 2) get the RDATA
+				rdata = ldns_rr_rdf(new_sig, 8;
+				# 3) Mangle it at random
+				new_sig._data[0] = rand() % 25 + 65 // 65-90 = A-Z
+				new_sig._data[1] = rand() % 25 + 65 // 65-90 = A-Z
+				new_sig._data[2] = rand() % 25 + 65 // 65-90 = A-Z
+				new_sig._data[3] = rand() % 25 + 65 // 65-90 = A-Z
+				# 4) Put the mangled data in place of the previous RDATA
+				ldns_rr_set_rdf	(new_sig, rdata, 8);
+				# Add the new RRSIG to the end of the existing RRSIGs
+				ldns_dnssec_rrs_add_rr	(	rrsets->signatures,  	rr);
+			}
 			LDNS_rr_list_cat_dnssec_rrs_clone(answer, rrsets->signatures);
 		}
 	} else {


### PR DESCRIPTION
Modifies the child to pad the response using fake RRSIGs.
Modifies the sibling to produce equal length responses whether the query was for an A or AAAA record.
